### PR TITLE
feat: add FreeBSD and NetBSD platforms

### DIFF
--- a/src/components/misc/BrowsePlatforms.vue
+++ b/src/components/misc/BrowsePlatforms.vue
@@ -18,7 +18,7 @@ import PlatformIcon from "./PlatformIcon.vue";
 import { useRouter } from "vue-router";
 
 const router = useRouter();
-const platforms = ["common", "linux", "openbsd", "osx", "windows", "android", "sunos"];
+const platforms = ["common", "linux", "freebsd", "netbsd", "openbsd", "osx", "windows", "android", "sunos"];
 
 const options = platforms.map((platform) => ({
   label: getPlatformDisplay(platform),

--- a/src/components/misc/BrowsePlatforms.vue
+++ b/src/components/misc/BrowsePlatforms.vue
@@ -18,7 +18,7 @@ import PlatformIcon from "./PlatformIcon.vue";
 import { useRouter } from "vue-router";
 
 const router = useRouter();
-const platforms = ["common", "linux", "freebsd", "netbsd", "openbsd", "osx", "windows", "android", "sunos"];
+const platforms = ["android", "common", "freebsd", "linux", "netbsd", "openbsd", "osx", "sunos", "windows"];
 
 const options = platforms.map((platform) => ({
   label: getPlatformDisplay(platform),

--- a/src/components/search/composables/getDefaultPlatforms.ts
+++ b/src/components/search/composables/getDefaultPlatforms.ts
@@ -4,40 +4,40 @@ export function getDefaultPlatforms(): Platform[] {
   const platforms: Platform[] = ["common"];
   const navigatorPlatform = navigator?.platform?.toLowerCase();
 
-    if (navigatorPlatform.includes("android")) {
-     platforms.push("android");
-    }
+  if (navigatorPlatform.includes("android")) {
+    platforms.push("android");
+  }
 
-    if (navigatorPlatform.includes("freebsd")){
-      platforms.push("freebsd");
-    }
+  if (navigatorPlatform.includes("freebsd")){
+    platforms.push("freebsd");
+  }
 
-    if (navigatorPlatform.includes("linux")) {
-      platforms.push("linux");
-    }
+  if (navigatorPlatform.includes("linux")) {
+    platforms.push("linux");
+  }
 
-    if (navigatorPlatform.includes("mac")) {
-      platforms.push("osx");
+  if (navigatorPlatform.includes("mac")) {
+    platforms.push("osx");
+    return platforms;
+  }
+
+  if (navigatorPlatform.includes("netbsd")){
+    platforms.push("netbsd");
+  }
+
+  if (navigatorPlatform.includes("openbsd")){
+    platforms.push("openbsd");
+    return platforms;
+  }
+
+  if (navigatorPlatform.includes("sunos")) {
+    platforms.push("sunos");
+  }
+
+  if (navigatorPlatform) {
+    if (navigatorPlatform.includes("win")) {
+      platforms.push("windows");
       return platforms;
-    }
-
-    if (navigatorPlatform.includes("netbsd")){
-      platforms.push("netbsd");
-    }
-
-    if (navigatorPlatform.includes("openbsd")){
-      platforms.push("openbsd");
-      return platforms;
-    }
-
-    if (navigatorPlatform.includes("sunos")) {
-      platforms.push("sunos");
-    }
-
-    if (navigatorPlatform) {
-      if (navigatorPlatform.includes("win")) {
-        platforms.push("windows");
-        return platforms;
     }
   }
 

--- a/src/components/search/composables/getDefaultPlatforms.ts
+++ b/src/components/search/composables/getDefaultPlatforms.ts
@@ -1,18 +1,19 @@
-type Platform = "common" | "openbsd" | "osx" | "linux" | "windows" | "android" | "sunos";
+type Platform = "android" | "common" | "freebsd" | "linux" | "netbsd" | "openbsd" | "osx" | "windows" | "sunos";
 
 export function getDefaultPlatforms(): Platform[] {
   const platforms: Platform[] = ["common"];
   const navigatorPlatform = navigator?.platform?.toLowerCase();
 
-  if (navigatorPlatform) {
-    if (navigatorPlatform.includes("win")) {
-      platforms.push("windows");
-      return platforms;
+    if (navigatorPlatform.includes("android")) {
+     platforms.push("android");
     }
 
-    if (navigatorPlatform.includes("openbsd")){
-      platforms.push("openbsd");
-      return platforms;
+    if (navigatorPlatform.includes("freebsd")){
+      platforms.push("freebsd");
+    }
+
+    if (navigatorPlatform.includes("linux")) {
+      platforms.push("linux");
     }
 
     if (navigatorPlatform.includes("mac")) {
@@ -20,16 +21,23 @@ export function getDefaultPlatforms(): Platform[] {
       return platforms;
     }
 
-    if (navigatorPlatform.includes("linux")) {
-      platforms.push("linux");
+    if (navigatorPlatform.includes("netbsd")){
+      platforms.push("netbsd");
     }
 
-    if (navigatorPlatform.includes("android")) {
-      platforms.push("android");
+    if (navigatorPlatform.includes("openbsd")){
+      platforms.push("openbsd");
+      return platforms;
     }
 
     if (navigatorPlatform.includes("sunos")) {
       platforms.push("sunos");
+    }
+
+    if (navigatorPlatform) {
+      if (navigatorPlatform.includes("win")) {
+        platforms.push("windows");
+        return platforms;
     }
   }
 
@@ -38,28 +46,36 @@ export function getDefaultPlatforms(): Platform[] {
   )?.userAgentData?.platform?.toLowerCase();
 
   if (uaPlatform) {
-    if (uaPlatform.includes("win")) {
-      platforms.push("windows");
+    if (uaPlatform.includes("android")) {
+      platforms.push("android");
     }
 
-    if (uaPlatform.includes("openbsd")){
-      platforms.push("openbsd");
-    }
-
-    if (uaPlatform.includes("mac")) {
-      platforms.push("osx");
+    if (uaPlatform.includes("freebsd")) {
+      platforms.push("freebsd");
     }
 
     if (uaPlatform.includes("linux")) {
       platforms.push("linux");
     }
 
-    if (uaPlatform.includes("android")) {
-      platforms.push("android");
+    if (uaPlatform.includes("mac")) {
+      platforms.push("osx");
+    }
+
+    if (uaPlatform.includes("netbsd")){
+      platforms.push("netbsd");
+    }
+
+    if (uaPlatform.includes("openbsd")){
+      platforms.push("openbsd");
     }
 
     if (uaPlatform.includes("sunos")) {
       platforms.push("sunos");
+    }
+
+    if (uaPlatform.includes("win")) {
+      platforms.push("windows");
     }
   }
 

--- a/src/data/tldr-pages/display/platform.ts
+++ b/src/data/tldr-pages/display/platform.ts
@@ -1,11 +1,13 @@
 const displayMap = {
+  android: "Android",
   common: "Common",
+  freebsd: "FreeBSD",
   linux: "Linux",
+  netbsd: "NetBSD",
   openbsd: "OpenBSD",
   osx: "macOS",
-  windows: "Windows",
-  android: "Android",
   sunos: "SunOS",
+  windows: "Windows",
 } as Record<string, string>;
 
 export function getPlatformDisplay(platform: string) {


### PR DESCRIPTION
## Changes

- Support for the newly added "FreeBSD" and "NetBSD" platforms. (Currently, there is only 1 page in each of the platforms, we are working on adding more in the future.)
- Arrange the platforms in alphabetical order.

---

This PR marks the completion of adding support for all major BSD platforms that I started with #18

---

## Reference Images

![Screenshot from 2023-10-29 16-15-30](https://github.com/InBrowserApp/tldr.inbrowser.app/assets/26346867/58aa01e2-c0f6-4cba-a66d-b1d03dd2e39c)
![Screenshot from 2023-10-29 16-15-49](https://github.com/InBrowserApp/tldr.inbrowser.app/assets/26346867/51d28f7e-a2e4-4084-89d7-ccd3ab4607f0)
![Screenshot from 2023-10-29 16-16-06](https://github.com/InBrowserApp/tldr.inbrowser.app/assets/26346867/372ed988-b81c-42e0-a77e-8fa0c4296343)

## Checklist

- [x] Tested the changes locally with `npm run dev` and in production with `npm run build`.