### PR TITLE
fix the moz namespace in opensearch.xml (#14)

### DIFF
--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
   <ShortName>tldr</ShortName>
   <Description>Search for tldr-pages</Description>
   <InputEncoding>UTF-8</InputEncoding>


### PR DESCRIPTION
The `moz` namespace was not declared, so the `moz:SearchForm` node was invalid, preventing Firefox from registering the search engine.

Fixes #14 